### PR TITLE
trim redundant css from foreignObject labels

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -249,7 +249,7 @@ By default the label is a `<foreignObject>`, and a Font Awesome `@import` is inc
       class="nodeLabel">
       <div
         xmlns="http://www.w3.org/1999/xhtml"
-        style="display: table-cell; white-space: nowrap; line-height: 1.5; max-width: 200px; text-align: center; vertical-align: middle; width: 68.5px; height: 48px;">
+        style="display: table-cell; white-space: nowrap; text-align: center; vertical-align: middle; width: 68.5px; height: 48px;">
         <span
           class="nodeLabel">
           <p>Hello</p>

--- a/src/Naiad/Rendering/SvgForeignObject.cs
+++ b/src/Naiad/Rendering/SvgForeignObject.cs
@@ -13,7 +13,7 @@ public class SvgForeignObject : SvgElement
         builder.Append(CultureInfo.InvariantCulture, $"<foreignObject x='{X:0.##}' y='{Y:0.##}' width='{Width:0.##}' height='{Height:0.##}'");
         CommonAttributes(builder);
         builder.Append('>');
-        builder.Append(CultureInfo.InvariantCulture, $"<div xmlns='http://www.w3.org/1999/xhtml' style='display: table-cell; white-space: nowrap; line-height: 1.5; max-width: 200px; text-align: center; vertical-align: middle; width: {Width:0.##}px; height: {Height:0.##}px;'>");
+        builder.Append(CultureInfo.InvariantCulture, $"<div xmlns='http://www.w3.org/1999/xhtml' style='display: table-cell; white-space: nowrap; text-align: center; vertical-align: middle; width: {Width:0.##}px; height: {Height:0.##}px;'>");
         builder.Append($"<span class='nodeLabel'>{HtmlContent}</span>");
         builder.Append("</div>");
         builder.Append("</foreignObject>");

--- a/src/Tests/AllowHtmlElements/AllowHtmlElementsTests.SingleNodeHtml.verified.svg
+++ b/src/Tests/AllowHtmlElements/AllowHtmlElementsTests.SingleNodeHtml.verified.svg
@@ -128,7 +128,7 @@
       class="nodeLabel">
       <div
         xmlns="http://www.w3.org/1999/xhtml"
-        style="display: table-cell; white-space: nowrap; line-height: 1.5; max-width: 200px; text-align: center; vertical-align: middle; width: 68.5px; height: 48px;">
+        style="display: table-cell; white-space: nowrap; text-align: center; vertical-align: middle; width: 68.5px; height: 48px;">
         <span
           class="nodeLabel">
           <p>Hello</p>

--- a/src/Tests/Flowchart/FlowchartTests.Complex.verified.svg
+++ b/src/Tests/Flowchart/FlowchartTests.Complex.verified.svg
@@ -138,7 +138,7 @@
       class="edgeLabel">
       <div
         xmlns="http://www.w3.org/1999/xhtml"
-        style="display: table-cell; white-space: nowrap; line-height: 1.5; max-width: 200px; text-align: center; vertical-align: middle; width: 88px; height: 24px;">
+        style="display: table-cell; white-space: nowrap; text-align: center; vertical-align: middle; width: 88px; height: 24px;">
         <span
           class="nodeLabel">
           <p>Get money</p>
@@ -175,7 +175,7 @@
       class="edgeLabel">
       <div
         xmlns="http://www.w3.org/1999/xhtml"
-        style="display: table-cell; white-space: nowrap; line-height: 1.5; max-width: 200px; text-align: center; vertical-align: middle; width: 40px; height: 24px;">
+        style="display: table-cell; white-space: nowrap; text-align: center; vertical-align: middle; width: 40px; height: 24px;">
         <span
           class="nodeLabel">
           <p>One</p>
@@ -205,7 +205,7 @@
       class="edgeLabel">
       <div
         xmlns="http://www.w3.org/1999/xhtml"
-        style="display: table-cell; white-space: nowrap; line-height: 1.5; max-width: 200px; text-align: center; vertical-align: middle; width: 40px; height: 24px;">
+        style="display: table-cell; white-space: nowrap; text-align: center; vertical-align: middle; width: 40px; height: 24px;">
         <span
           class="nodeLabel">
           <p>Two</p>
@@ -235,7 +235,7 @@
       class="edgeLabel">
       <div
         xmlns="http://www.w3.org/1999/xhtml"
-        style="display: table-cell; white-space: nowrap; line-height: 1.5; max-width: 200px; text-align: center; vertical-align: middle; width: 56px; height: 24px;">
+        style="display: table-cell; white-space: nowrap; text-align: center; vertical-align: middle; width: 56px; height: 24px;">
         <span
           class="nodeLabel">
           <p>Three</p>
@@ -255,7 +255,7 @@
       class="nodeLabel">
       <div
         xmlns="http://www.w3.org/1999/xhtml"
-        style="display: table-cell; white-space: nowrap; line-height: 1.5; max-width: 200px; text-align: center; vertical-align: middle; width: 99.3px; height: 48px;">
+        style="display: table-cell; white-space: nowrap; text-align: center; vertical-align: middle; width: 99.3px; height: 48px;">
         <span
           class="nodeLabel">
           <p>Christmas</p>
@@ -275,7 +275,7 @@
       class="nodeLabel">
       <div
         xmlns="http://www.w3.org/1999/xhtml"
-        style="display: table-cell; white-space: nowrap; line-height: 1.5; max-width: 200px; text-align: center; vertical-align: middle; width: 114.7px; height: 48px;">
+        style="display: table-cell; white-space: nowrap; text-align: center; vertical-align: middle; width: 114.7px; height: 48px;">
         <span
           class="nodeLabel">
           <p>Go shopping</p>
@@ -295,7 +295,7 @@
       class="nodeLabel">
       <div
         xmlns="http://www.w3.org/1999/xhtml"
-        style="display: table-cell; white-space: nowrap; line-height: 1.5; max-width: 200px; text-align: center; vertical-align: middle; width: 171.36px; height: 67.2px;">
+        style="display: table-cell; white-space: nowrap; text-align: center; vertical-align: middle; width: 171.36px; height: 67.2px;">
         <span
           class="nodeLabel">
           <p>Let me think</p>
@@ -315,7 +315,7 @@
       class="nodeLabel">
       <div
         xmlns="http://www.w3.org/1999/xhtml"
-        style="display: table-cell; white-space: nowrap; line-height: 1.5; max-width: 200px; text-align: center; vertical-align: middle; width: 76.2px; height: 48px;">
+        style="display: table-cell; white-space: nowrap; text-align: center; vertical-align: middle; width: 76.2px; height: 48px;">
         <span
           class="nodeLabel">
           <p>Laptop</p>
@@ -335,7 +335,7 @@
       class="nodeLabel">
       <div
         xmlns="http://www.w3.org/1999/xhtml"
-        style="display: table-cell; white-space: nowrap; line-height: 1.5; max-width: 200px; text-align: center; vertical-align: middle; width: 76.2px; height: 48px;">
+        style="display: table-cell; white-space: nowrap; text-align: center; vertical-align: middle; width: 76.2px; height: 48px;">
         <span
           class="nodeLabel">
           <p>iPhone</p>
@@ -355,7 +355,7 @@
       class="nodeLabel">
       <div
         xmlns="http://www.w3.org/1999/xhtml"
-        style="display: table-cell; white-space: nowrap; line-height: 1.5; max-width: 200px; text-align: center; vertical-align: middle; width: 73.1px; height: 48px;">
+        style="display: table-cell; white-space: nowrap; text-align: center; vertical-align: middle; width: 73.1px; height: 48px;">
         <span
           class="nodeLabel">
           <p>

--- a/src/Tests/Flowchart/FlowchartTests.EdgeLabels.verified.svg
+++ b/src/Tests/Flowchart/FlowchartTests.EdgeLabels.verified.svg
@@ -138,7 +138,7 @@
       class="edgeLabel">
       <div
         xmlns="http://www.w3.org/1999/xhtml"
-        style="display: table-cell; white-space: nowrap; line-height: 1.5; max-width: 200px; text-align: center; vertical-align: middle; width: 40px; height: 24px;">
+        style="display: table-cell; white-space: nowrap; text-align: center; vertical-align: middle; width: 40px; height: 24px;">
         <span
           class="nodeLabel">
           <p>Yes</p>
@@ -168,7 +168,7 @@
       class="edgeLabel">
       <div
         xmlns="http://www.w3.org/1999/xhtml"
-        style="display: table-cell; white-space: nowrap; line-height: 1.5; max-width: 200px; text-align: center; vertical-align: middle; width: 32px; height: 24px;">
+        style="display: table-cell; white-space: nowrap; text-align: center; vertical-align: middle; width: 32px; height: 24px;">
         <span
           class="nodeLabel">
           <p>No</p>
@@ -188,7 +188,7 @@
       class="nodeLabel">
       <div
         xmlns="http://www.w3.org/1999/xhtml"
-        style="display: table-cell; white-space: nowrap; line-height: 1.5; max-width: 200px; text-align: center; vertical-align: middle; width: 37.7px; height: 48px;">
+        style="display: table-cell; white-space: nowrap; text-align: center; vertical-align: middle; width: 37.7px; height: 48px;">
         <span
           class="nodeLabel">
           <p>A</p>
@@ -208,7 +208,7 @@
       class="nodeLabel">
       <div
         xmlns="http://www.w3.org/1999/xhtml"
-        style="display: table-cell; white-space: nowrap; line-height: 1.5; max-width: 200px; text-align: center; vertical-align: middle; width: 37.7px; height: 48px;">
+        style="display: table-cell; white-space: nowrap; text-align: center; vertical-align: middle; width: 37.7px; height: 48px;">
         <span
           class="nodeLabel">
           <p>B</p>
@@ -228,7 +228,7 @@
       class="nodeLabel">
       <div
         xmlns="http://www.w3.org/1999/xhtml"
-        style="display: table-cell; white-space: nowrap; line-height: 1.5; max-width: 200px; text-align: center; vertical-align: middle; width: 37.7px; height: 48px;">
+        style="display: table-cell; white-space: nowrap; text-align: center; vertical-align: middle; width: 37.7px; height: 48px;">
         <span
           class="nodeLabel">
           <p>C</p>

--- a/src/Tests/Flowchart/FlowchartTests.GraphKeyword.verified.svg
+++ b/src/Tests/Flowchart/FlowchartTests.GraphKeyword.verified.svg
@@ -142,7 +142,7 @@
       class="nodeLabel">
       <div
         xmlns="http://www.w3.org/1999/xhtml"
-        style="display: table-cell; white-space: nowrap; line-height: 1.5; max-width: 200px; text-align: center; vertical-align: middle; width: 37.7px; height: 48px;">
+        style="display: table-cell; white-space: nowrap; text-align: center; vertical-align: middle; width: 37.7px; height: 48px;">
         <span
           class="nodeLabel">
           <p>A</p>
@@ -162,7 +162,7 @@
       class="nodeLabel">
       <div
         xmlns="http://www.w3.org/1999/xhtml"
-        style="display: table-cell; white-space: nowrap; line-height: 1.5; max-width: 200px; text-align: center; vertical-align: middle; width: 37.7px; height: 48px;">
+        style="display: table-cell; white-space: nowrap; text-align: center; vertical-align: middle; width: 37.7px; height: 48px;">
         <span
           class="nodeLabel">
           <p>B</p>
@@ -182,7 +182,7 @@
       class="nodeLabel">
       <div
         xmlns="http://www.w3.org/1999/xhtml"
-        style="display: table-cell; white-space: nowrap; line-height: 1.5; max-width: 200px; text-align: center; vertical-align: middle; width: 37.7px; height: 48px;">
+        style="display: table-cell; white-space: nowrap; text-align: center; vertical-align: middle; width: 37.7px; height: 48px;">
         <span
           class="nodeLabel">
           <p>C</p>

--- a/src/Tests/Flowchart/FlowchartTests.IconPackIcon.verified.svg
+++ b/src/Tests/Flowchart/FlowchartTests.IconPackIcon.verified.svg
@@ -135,7 +135,7 @@
       class="nodeLabel">
       <div
         xmlns="http://www.w3.org/1999/xhtml"
-        style="display: table-cell; white-space: nowrap; line-height: 1.5; max-width: 200px; text-align: center; vertical-align: middle; width: 103.9px; height: 48px;">
+        style="display: table-cell; white-space: nowrap; text-align: center; vertical-align: middle; width: 103.9px; height: 48px;">
         <span
           class="nodeLabel">
           <p>
@@ -167,7 +167,7 @@
       class="nodeLabel">
       <div
         xmlns="http://www.w3.org/1999/xhtml"
-        style="display: table-cell; white-space: nowrap; line-height: 1.5; max-width: 200px; text-align: center; vertical-align: middle; width: 88.5px; height: 48px;">
+        style="display: table-cell; white-space: nowrap; text-align: center; vertical-align: middle; width: 88.5px; height: 48px;">
         <span
           class="nodeLabel">
           <p>

--- a/src/Tests/Flowchart/FlowchartTests.NestedSubgraphs.verified.svg
+++ b/src/Tests/Flowchart/FlowchartTests.NestedSubgraphs.verified.svg
@@ -187,7 +187,7 @@
       class="nodeLabel">
       <div
         xmlns="http://www.w3.org/1999/xhtml"
-        style="display: table-cell; white-space: nowrap; line-height: 1.5; max-width: 200px; text-align: center; vertical-align: middle; width: 60.8px; height: 48px;">
+        style="display: table-cell; white-space: nowrap; text-align: center; vertical-align: middle; width: 60.8px; height: 48px;">
         <span
           class="nodeLabel">
           <p>User</p>
@@ -207,7 +207,7 @@
       class="nodeLabel">
       <div
         xmlns="http://www.w3.org/1999/xhtml"
-        style="display: table-cell; white-space: nowrap; line-height: 1.5; max-width: 200px; text-align: center; vertical-align: middle; width: 107px; height: 48px;">
+        style="display: table-cell; white-space: nowrap; text-align: center; vertical-align: middle; width: 107px; height: 48px;">
         <span
           class="nodeLabel">
           <p>Controller</p>
@@ -227,7 +227,7 @@
       class="nodeLabel">
       <div
         xmlns="http://www.w3.org/1999/xhtml"
-        style="display: table-cell; white-space: nowrap; line-height: 1.5; max-width: 200px; text-align: center; vertical-align: middle; width: 83.9px; height: 48px;">
+        style="display: table-cell; white-space: nowrap; text-align: center; vertical-align: middle; width: 83.9px; height: 48px;">
         <span
           class="nodeLabel">
           <p>Service</p>
@@ -247,7 +247,7 @@
       class="nodeLabel">
       <div
         xmlns="http://www.w3.org/1999/xhtml"
-        style="display: table-cell; white-space: nowrap; line-height: 1.5; max-width: 200px; text-align: center; vertical-align: middle; width: 91.6px; height: 48px;">
+        style="display: table-cell; white-space: nowrap; text-align: center; vertical-align: middle; width: 91.6px; height: 48px;">
         <span
           class="nodeLabel">
           <p>Database</p>

--- a/src/Tests/Flowchart/FlowchartTests.Shapes.verified.svg
+++ b/src/Tests/Flowchart/FlowchartTests.Shapes.verified.svg
@@ -128,7 +128,7 @@
       class="nodeLabel">
       <div
         xmlns="http://www.w3.org/1999/xhtml"
-        style="display: table-cell; white-space: nowrap; line-height: 1.5; max-width: 200px; text-align: center; vertical-align: middle; width: 99.3px; height: 48px;">
+        style="display: table-cell; white-space: nowrap; text-align: center; vertical-align: middle; width: 99.3px; height: 48px;">
         <span
           class="nodeLabel">
           <p>Rectangle</p>
@@ -148,7 +148,7 @@
       class="nodeLabel">
       <div
         xmlns="http://www.w3.org/1999/xhtml"
-        style="display: table-cell; white-space: nowrap; line-height: 1.5; max-width: 200px; text-align: center; vertical-align: middle; width: 83.9px; height: 48px;">
+        style="display: table-cell; white-space: nowrap; text-align: center; vertical-align: middle; width: 83.9px; height: 48px;">
         <span
           class="nodeLabel">
           <p>Rounded</p>
@@ -168,7 +168,7 @@
       class="nodeLabel">
       <div
         xmlns="http://www.w3.org/1999/xhtml"
-        style="display: table-cell; white-space: nowrap; line-height: 1.5; max-width: 200px; text-align: center; vertical-align: middle; width: 117.46px; height: 67.2px;">
+        style="display: table-cell; white-space: nowrap; text-align: center; vertical-align: middle; width: 117.46px; height: 67.2px;">
         <span
           class="nodeLabel">
           <p>Diamond</p>
@@ -188,7 +188,7 @@
       class="nodeLabel">
       <div
         xmlns="http://www.w3.org/1999/xhtml"
-        style="display: table-cell; white-space: nowrap; line-height: 1.5; max-width: 200px; text-align: center; vertical-align: middle; width: 76.2px; height: 76.2px;">
+        style="display: table-cell; white-space: nowrap; text-align: center; vertical-align: middle; width: 76.2px; height: 76.2px;">
         <span
           class="nodeLabel">
           <p>Circle</p>

--- a/src/Tests/Flowchart/FlowchartTests.Simple.verified.svg
+++ b/src/Tests/Flowchart/FlowchartTests.Simple.verified.svg
@@ -142,7 +142,7 @@
       class="nodeLabel">
       <div
         xmlns="http://www.w3.org/1999/xhtml"
-        style="display: table-cell; white-space: nowrap; line-height: 1.5; max-width: 200px; text-align: center; vertical-align: middle; width: 68.5px; height: 48px;">
+        style="display: table-cell; white-space: nowrap; text-align: center; vertical-align: middle; width: 68.5px; height: 48px;">
         <span
           class="nodeLabel">
           <p>Start</p>
@@ -162,7 +162,7 @@
       class="nodeLabel">
       <div
         xmlns="http://www.w3.org/1999/xhtml"
-        style="display: table-cell; white-space: nowrap; line-height: 1.5; max-width: 200px; text-align: center; vertical-align: middle; width: 83.9px; height: 48px;">
+        style="display: table-cell; white-space: nowrap; text-align: center; vertical-align: middle; width: 83.9px; height: 48px;">
         <span
           class="nodeLabel">
           <p>Process</p>
@@ -182,7 +182,7 @@
       class="nodeLabel">
       <div
         xmlns="http://www.w3.org/1999/xhtml"
-        style="display: table-cell; white-space: nowrap; line-height: 1.5; max-width: 200px; text-align: center; vertical-align: middle; width: 53.1px; height: 48px;">
+        style="display: table-cell; white-space: nowrap; text-align: center; vertical-align: middle; width: 53.1px; height: 48px;">
         <span
           class="nodeLabel">
           <p>End</p>

--- a/src/Tests/Flowchart/FlowchartTests.Subgraphs.verified.svg
+++ b/src/Tests/Flowchart/FlowchartTests.Subgraphs.verified.svg
@@ -201,7 +201,7 @@
       class="nodeLabel">
       <div
         xmlns="http://www.w3.org/1999/xhtml"
-        style="display: table-cell; white-space: nowrap; line-height: 1.5; max-width: 200px; text-align: center; vertical-align: middle; width: 68.5px; height: 48px;">
+        style="display: table-cell; white-space: nowrap; text-align: center; vertical-align: middle; width: 68.5px; height: 48px;">
         <span
           class="nodeLabel">
           <p>Start</p>
@@ -221,7 +221,7 @@
       class="nodeLabel">
       <div
         xmlns="http://www.w3.org/1999/xhtml"
-        style="display: table-cell; white-space: nowrap; line-height: 1.5; max-width: 200px; text-align: center; vertical-align: middle; width: 76.2px; height: 48px;">
+        style="display: table-cell; white-space: nowrap; text-align: center; vertical-align: middle; width: 76.2px; height: 48px;">
         <span
           class="nodeLabel">
           <p>Web UI</p>
@@ -241,7 +241,7 @@
       class="nodeLabel">
       <div
         xmlns="http://www.w3.org/1999/xhtml"
-        style="display: table-cell; white-space: nowrap; line-height: 1.5; max-width: 200px; text-align: center; vertical-align: middle; width: 99.3px; height: 48px;">
+        style="display: table-cell; white-space: nowrap; text-align: center; vertical-align: middle; width: 99.3px; height: 48px;">
         <span
           class="nodeLabel">
           <p>Mobile UI</p>
@@ -261,7 +261,7 @@
       class="nodeLabel">
       <div
         xmlns="http://www.w3.org/1999/xhtml"
-        style="display: table-cell; white-space: nowrap; line-height: 1.5; max-width: 200px; text-align: center; vertical-align: middle; width: 53.1px; height: 48px;">
+        style="display: table-cell; white-space: nowrap; text-align: center; vertical-align: middle; width: 53.1px; height: 48px;">
         <span
           class="nodeLabel">
           <p>API</p>
@@ -281,7 +281,7 @@
       class="nodeLabel">
       <div
         xmlns="http://www.w3.org/1999/xhtml"
-        style="display: table-cell; white-space: nowrap; line-height: 1.5; max-width: 200px; text-align: center; vertical-align: middle; width: 91.6px; height: 48px;">
+        style="display: table-cell; white-space: nowrap; text-align: center; vertical-align: middle; width: 91.6px; height: 48px;">
         <span
           class="nodeLabel">
           <p>Database</p>

--- a/src/Tests/Mindmap/MindmapTests.Icons.verified.svg
+++ b/src/Tests/Mindmap/MindmapTests.Icons.verified.svg
@@ -81,7 +81,7 @@
     height="18">
     <div
       xmlns="http://www.w3.org/1999/xhtml"
-      style="display: table-cell; white-space: nowrap; line-height: 1.5; max-width: 200px; text-align: center; vertical-align: middle; width: 18px; height: 18px;">
+      style="display: table-cell; white-space: nowrap; text-align: center; vertical-align: middle; width: 18px; height: 18px;">
       <span
         class="nodeLabel">
         <i


### PR DESCRIPTION
Drop `max-width: 200px` (inert when an explicit width is set, and clamps labels wider than 200px) and `line-height: 1.5` (no effect on a single line centered via vertical-align). The rasterizer centers labels from the foreignObject geometry and never reads this style, so PNG output is unchanged; only browser rendering consumes it.
Regenerate the affected .verified.svg baselines and resync the readme.