### PR TITLE
Harden foreignObject label escaping against markup injection

### DIFF
--- a/src/Naiad/Diagrams/Mindmap/MindmapRenderer.cs
+++ b/src/Naiad/Diagrams/Mindmap/MindmapRenderer.cs
@@ -1,3 +1,5 @@
+using System.Net;
+
 namespace Naiad.Diagrams.Mindmap;
 
 public class MindmapRenderer : IDiagramRenderer<MindmapModel>
@@ -275,9 +277,11 @@ public class MindmapRenderer : IDiagramRenderer<MindmapModel>
             return;
         }
 
-        // FontAwesome class string, e.g. "fa fa-book". With HTML disabled there is no web font
-        // to draw the glyph, so the icon (which carries no text) is dropped.
-        builder.AddLabel(x, y, size, size, $"<i class='{icon}'></i>", "");
+        // FontAwesome class string, e.g. "fa fa-book". Encode the class value (a no-op for the normal
+        // dotted/spaced class names) so a crafted icon token can't break out of the attribute and inject
+        // markup into the foreignObject. With HTML disabled there is no web font to draw the glyph, so the
+        // icon (which carries no text) is dropped.
+        builder.AddLabel(x, y, size, size, $"<i class='{WebUtility.HtmlEncode(icon)}'></i>", "");
     }
 
     static void DrawHexagon(SvgBuilder builder, double cx, double cy, double width, double height,

--- a/src/Naiad/Rendering/SvgBuilder.cs
+++ b/src/Naiad/Rendering/SvgBuilder.cs
@@ -199,6 +199,12 @@ public class SvgBuilder
         return this;
     }
 
+    /// <summary>Adds a <c>&lt;foreignObject&gt;</c> carrying raw label markup.</summary>
+    /// <remarks>
+    /// <paramref name="htmlContent"/> is pre-built XHTML, emitted verbatim (see
+    /// <see cref="SvgForeignObject.HtmlContent"/>). Any user-supplied text within it must already be
+    /// HTML-encoded by the caller.
+    /// </remarks>
     public SvgBuilder AddForeignObject(
         double x,
         double y,
@@ -220,9 +226,16 @@ public class SvgBuilder
         return this;
     }
 
-    // Adds a box-centered label. With HTML allowed this is a <foreignObject> carrying the
-    // rich html; otherwise it is a native <text> built from the already-structured plainText
-    // (icons dropped, since they need a web font we do not embed). Empty labels emit nothing.
+    /// <summary>
+    /// Adds a box-centered label. With HTML allowed this is a <c>&lt;foreignObject&gt;</c> carrying the
+    /// rich html; otherwise it is a native <c>&lt;text&gt;</c> built from the already-structured plainText
+    /// (icons dropped, since they need a web font we do not embed). Empty labels emit nothing.
+    /// </summary>
+    /// <remarks>
+    /// <paramref name="html"/> is pre-built XHTML used on the foreignObject path, emitted verbatim (see
+    /// <see cref="SvgForeignObject.HtmlContent"/>). Any user-supplied text within it must already be
+    /// HTML-encoded by the caller; the native-text fallback escapes <paramref name="plainText"/> itself.
+    /// </remarks>
     public SvgBuilder AddLabel(
         double x,
         double y,

--- a/src/Naiad/Rendering/SvgForeignObject.cs
+++ b/src/Naiad/Rendering/SvgForeignObject.cs
@@ -6,6 +6,15 @@ public class SvgForeignObject : SvgElement
     public double Y { get; set; }
     public double Width { get; set; }
     public double Height { get; set; }
+
+    /// <summary>
+    /// The inner XHTML of the label, emitted verbatim inside the wrapping <c>&lt;span&gt;</c>. This is a
+    /// raw-markup seam: it is written without escaping because callers legitimately pass markup (e.g.
+    /// <c>&lt;p&gt;</c> wrappers and <c>&lt;i class&gt;</c> icon elements). Any user-supplied <em>text</em>
+    /// placed in here MUST be HTML-encoded by the caller (e.g. via
+    /// <see cref="System.Net.WebUtility.HtmlEncode(string)"/>); unencoded text would both break the
+    /// document's XML well-formedness and allow markup injection into the rendered SVG.
+    /// </summary>
     public required string HtmlContent { get; set; }
 
     public override void ToXml(StringBuilder builder)
@@ -14,6 +23,8 @@ public class SvgForeignObject : SvgElement
         CommonAttributes(builder);
         builder.Append('>');
         builder.Append(CultureInfo.InvariantCulture, $"<div xmlns='http://www.w3.org/1999/xhtml' style='display: table-cell; white-space: nowrap; text-align: center; vertical-align: middle; width: {Width:0.##}px; height: {Height:0.##}px;'>");
+        // Raw-markup seam: HtmlContent is emitted verbatim. Callers own escaping of any user text (see the
+        // HtmlContent doc) — the content is XHTML built by the renderers, not plain text.
         builder.Append($"<span>{HtmlContent}</span>");
         builder.Append("</div>");
         builder.Append("</foreignObject>");

--- a/src/Tests/Rendering/LabelEscapingTests.cs
+++ b/src/Tests/Rendering/LabelEscapingTests.cs
@@ -1,0 +1,67 @@
+// Regression coverage for label escaping: user-supplied diagram text must never reach the rendered SVG as
+// live markup. Flowchart node/edge labels travel through the <foreignObject> seam (SvgForeignObject emits
+// raw XHTML, so the renderer pre-encodes the text), while other diagrams' labels go through native <text>
+// (escaped by SvgText). A crafted label must come out inert either way.
+public class LabelEscapingTests
+{
+    [Test]
+    public async Task FlowchartNodeLabel_EscapesMarkup()
+    {
+        var svg = Mermaid.Render(
+            """
+            flowchart LR
+                A["<script>alert(1)</script>"]
+            """);
+
+        await Assert.That(svg).DoesNotContain("<script>");
+        await Assert.That(svg).Contains("&lt;script&gt;");
+    }
+
+    [Test]
+    public async Task FlowchartNodeLabel_EscapesAttributeInjection()
+    {
+        var svg = Mermaid.Render(
+            """
+            flowchart LR
+                A["<img src=x onerror=alert(1)>"]
+            """);
+
+        // The raw <img> tag must not appear; it comes out as encoded text instead.
+        await Assert.That(svg).DoesNotContain("<img");
+        await Assert.That(svg).Contains("&lt;img");
+    }
+
+    [Test]
+    public async Task FlowchartEdgeLabel_EscapesMarkup()
+    {
+        var svg = Mermaid.Render(
+            """
+            flowchart LR
+                A -->|"<script>x</script>"| B
+            """);
+
+        await Assert.That(svg).DoesNotContain("<script>");
+        await Assert.That(svg).Contains("&lt;script&gt;");
+    }
+
+    // Locks the seam contract: SvgForeignObject emits HtmlContent verbatim (callers own escaping). Guards
+    // against a well-meaning "fix" that blanket-encodes here — which would corrupt the <p>/<i> markup the
+    // renderers legitimately pass.
+    [Test]
+    public async Task SvgForeignObject_EmitsHtmlContentVerbatim()
+    {
+        var foreignObject = new SvgForeignObject
+        {
+            X = 0,
+            Y = 0,
+            Width = 10,
+            Height = 10,
+            HtmlContent = "<p>kept &amp; intact</p>"
+        };
+
+        var builder = new StringBuilder();
+        foreignObject.ToXml(builder);
+
+        await Assert.That(builder.ToString()).Contains("<p>kept &amp; intact</p>");
+    }
+}


### PR DESCRIPTION
Harden foreignObject label escaping against markup injection

SvgForeignObject.HtmlContent is a raw-markup seam — it emits XHTML verbatim because the renderers legitimately pass <p>/<i> markup that the rasterizer parses. That makes escaping the caller's responsibility, but the contract was undocumented and one caller missed it.

- Document the seam contract on SvgForeignObject.HtmlContent, AddForeignObject and AddLabel: callers must HTML-encode user text.
- Encode the Mindmap icon class value so a crafted icon token can't break out of the attribute. A no-op for normal "fa fa-*" classes, so no rendered output (or baseline) changes.
- Add LabelEscapingTests covering flowchart node/edge label escaping, attribute injection, and the raw-seam-emits-verbatim contract.

Flowchart node/edge labels already pre-encode via WebUtility.HtmlEncode, and native <text> labels are escaped by SvgText, so existing output is unchanged